### PR TITLE
ci(workflow-templates): bump checkout to v5 (Node 24)

### DIFF
--- a/workflow-templates/apella-org.yml
+++ b/workflow-templates/apella-org.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     
     - name: Run a one-line script
       run: echo Hello from Apella Technology!

--- a/workflow-templates/apella-terraform-format-check.yml
+++ b/workflow-templates/apella-terraform-format-check.yml
@@ -12,7 +12,7 @@ jobs:
     name: Check that terraform files are formatted correctly
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: terraform fmt
         uses: dflook/terraform-fmt-check@v1


### PR DESCRIPTION
## Summary

GitHub is deprecating the **Node.js 20 runtime** for JavaScript actions (forced to Node 24 on **2026-06-16**, removed **2026-09-16**). `actions/checkout@v3` runs on the even-older **node16**. These org starter workflows are copied into repos via the GitHub "New workflow" UI, so bumping them here stops new repos from inheriting the deprecated pin.

- `workflow-templates/apella-org.yml`: `actions/checkout@v3 → v5`
- `workflow-templates/apella-terraform-format-check.yml`: `actions/checkout@v3 → v5`

`dflook/terraform-fmt-check@v1` is a Docker-based action (`runs.using: docker`), so it is unaffected by the Node deprecation and left unchanged.

## Context
This starter workflow is the likely origin of `checkout@v3` appearing in **39 repos** across the org. Existing repos still need their own bumps (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)